### PR TITLE
CI: add "jesec/rtorrent:latest" tag to rolling release

### DIFF
--- a/.github/workflows/publish-rolling.yml
+++ b/.github/workflows/publish-rolling.yml
@@ -84,7 +84,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Merge multi-arch Docker image manifests
-        run: docker buildx imagetools create -t jesec/rtorrent:master jesec/rtorrent:master-arm64 jesec/rtorrent:master-amd64
+        run: docker buildx imagetools create -t jesec/rtorrent:master -t jesec/rtorrent:latest jesec/rtorrent:master-arm64 jesec/rtorrent:master-amd64
 
       - name: Remove intermediate tags
         run: |


### PR DESCRIPTION
## Description

Docker's default tag is "latest", so when not specifying a tag when pulling/pushing a tag from/to Docker Hub "latest" is used. The "latest" tag was used for "jesec/rtorrent" previously but is not used anymore, leaving an outdated tag on Docker Hub. This outdated tag gets downloaded by default. This affects some of the docker-compose examples, too.

This PR adds the "latest" tag as a synonym for the "master" tag.

## Types of changes

- [ ] Breaking change (changes that break backward compatibility of public API or CLI - semver MAJOR)
- [ ] New feature (non-breaking change which adds functionality - semver MINOR)
- [x] Bug fix (non-breaking change which fixes an issue - semver PATCH)
