### PR TITLE
Optimize code paths of load_session_torrents

### DIFF
--- a/src/control.cc
+++ b/src/control.cc
@@ -87,8 +87,6 @@ Control::initialize() {
   m_core->listen_open();
   m_core->download_store()->enable(rpc::call_command_value("session.use_lock"));
 
-  m_core->set_hashing_view(*m_viewManager->find_throw("hashing"));
-
   m_ui->init(this);
 
   if (display::Canvas::isInitialized()) {

--- a/src/core/download_factory.cc
+++ b/src/core/download_factory.cc
@@ -352,13 +352,15 @@ DownloadFactory::receive_success() {
       rpc::parse_command_multiple_std(command, rpc::make_target(download));
     }
 
-    if (m_manager->download_list()->find(infohash) ==
-        m_manager->download_list()->end())
-      throw torrent::input_error("The newly created download was removed.");
+    if (!m_session) {
+      if (m_manager->download_list()->find(infohash) ==
+          m_manager->download_list()->end()) {
+        throw torrent::input_error("The newly created download was removed.");
+      }
 
-    if (!m_session)
       rpc::call_command(
         "d.state.set", (int64_t)m_start, rpc::make_target(download));
+    }
 
     rpc::commands.call_catch(m_session ? "event.download.inserted_session"
                                        : "event.download.inserted_new",

--- a/src/core/view.cc
+++ b/src/core/view.cc
@@ -244,6 +244,10 @@ View::prev_focus() {
 
 void
 View::sort() {
+  if (m_sortCurrent.is_empty()) {
+    return;
+  }
+
   Download* curFocus = focus() != end_visible() ? *focus() : nullptr;
 
   // Don't go randomly switching around equivalent elements.
@@ -371,7 +375,10 @@ View::clear_filter_on() {
 inline void
 View::insert_visible(Download* d) {
   iterator itr =
-    std::find_if(begin_visible(), end_visible(), [d, this](Download* download) {
+    m_sortNew.is_empty()
+      ? end_visible()
+      : std::find_if(
+          begin_visible(), end_visible(), [d, this](Download* download) {
       return view_downloads_compare(m_sortNew)(d, download);
     });
 

--- a/src/core/view.cc
+++ b/src/core/view.cc
@@ -326,11 +326,16 @@ View::filter_by(const torrent::Object& condition, View::base_type& result) {
 
 void
 View::filter_download(core::Download* download) {
-  iterator itr = std::find(base_type::begin(), base_type::end(), download);
+  iterator itr = std::find(base_type::end() - 1, base_type::end(), download);
 
-  if (itr == base_type::end())
+  if (itr == base_type::end()) {
+    itr = std::find(base_type::begin(), base_type::end() - 1, download);
+  }
+
+  if (itr == base_type::end()) {
     throw torrent::internal_error(
       "View::filter_download(...) could not find download.");
+  }
 
   if (view_downloads_filter(m_filter, m_temp_filter)(download)) {
     if (itr >= end_visible()) {
@@ -379,8 +384,8 @@ View::insert_visible(Download* d) {
       ? end_visible()
       : std::find_if(
           begin_visible(), end_visible(), [d, this](Download* download) {
-      return view_downloads_compare(m_sortNew)(d, download);
-    });
+            return view_downloads_compare(m_sortNew)(d, download);
+          });
 
   m_size++;
   m_focus += (m_focus >= position(itr));

--- a/src/main.cc
+++ b/src/main.cc
@@ -164,6 +164,7 @@ load_session_torrents() {
 
     // Replace with session torrent flag.
     f->set_session(true);
+    f->set_immediate(true);
     f->slot_finished([f, &progress_bar, entries_size]() {
       if (control->is_shutdown_received()) {
         throw std::runtime_error("shutdown received. aborting...");
@@ -176,11 +177,10 @@ load_session_torrents() {
       }
       delete f;
     });
+
     f->load(entries.path() + entry.d_name);
     f->commit();
   }
-
-  torrent::utils::priority_queue_perform(&taskScheduler, cachedTime);
 
   if (progress_bar != nullptr) {
     progress_bar->mark_as_completed();

--- a/src/main.cc
+++ b/src/main.cc
@@ -393,8 +393,6 @@ main(int argc, char** argv) {
       "view.add = default\n"
 
       "view.add = name\n"
-      "view.sort_new     = name,((less,((d.name))))\n"
-      "view.sort_current = name,((less,((d.name))))\n"
 
       "view.add = active\n"
       "view.filter = active,((false))\n"
@@ -444,9 +442,6 @@ main(int argc, char** argv) {
       "view.filter_on = "
       "leeching,event.download.resumed,event.download.paused,event.download."
       "finished\n"
-
-      "schedule2 = view.main,10,10,((view.sort,main,20))\n"
-      "schedule2 = view.name,10,10,((view.sort,name,20))\n"
 
       "schedule2 = session_save,1200,1200,((session.save))\n"
       "schedule2 = low_diskspace,5,60,((close_low_diskspace,500M))\n"
@@ -612,6 +607,19 @@ main(int argc, char** argv) {
       const auto pair = cmd2.front();
       rpc::call_command_set_std_string(pair.first, pair.second);
       cmd2.pop();
+    }
+
+    // Sorting is O(n*log(n)) and very expensive
+    // RPC user does not rely on rTorrent for sorted list
+    // Only set view sorting and periodic resorting when not in daemon mode
+    if (!rpc::call_command_value("system.daemon")) {
+      rpc::parse_command_multiple(
+        rpc::make_target(),
+        "view.sort_new     = name,((less,((d.name))))\n"
+        "view.sort_current = name,((less,((d.name))))\n"
+
+        "schedule2 = view.main,10,10,((view.sort,main,20))\n"
+        "schedule2 = view.name,10,10,((view.sort,name,20))\n");
     }
 
     LT_LOG(


### PR DESCRIPTION
co: jesec/libtorrent#5

| Torrents / Time to Load (seconds) | w/o this PR | w/ this PR |
| --------------------------------- | ----------- | ---------- |
| 100                               | 0.0988322   | 0.100783   |
| 500                               | 0.316298    | 0.2778484  |
| 1000                              | 0.5230036   | 0.3384636  |
| 2000                              | 1.1452586   | 0.488410   |
| 5000                              | 5.4459174   | 0.8843604  |
| 10000                             | 24.0999498  | 1.574791   |
| 15000                             | 62.0685972  | 2.3090436  |
| 20000                             | 122.2196932 | 3.118153   |
| 25000                             | 194.3020272 | 3.9291368  |
| 30000                             | 301.594044  | 4.7896626  |

---

```
main: batch checking after the whole session loaded

"receive_hashing_changed" is an O(n) operation, where n is the
number of entities in the download list. It is not efficient when
the function is triggered every time a torrent has been inserted
by "load_session_torrents", making the whole operation O(n^2).

Thus, delay checking until the whole session has been loaded.
```

```
view: add a fast path for newly added element

filter_download is often called after a new element is added.

Since new elements are always inserted to the back, it is more
efficient to check the last element first, so we have O(1) instead
of O(n) in this common case.
```

```
view: insert directly if sorting is not required

O(n) -> O(1)
```

```
main: only set view sorting and periodic resorting when not in daemon mode

Sorting is O(n*log(n)) and very expensive. RPC user (such as Flood
or ruTorrent) does not rely on rTorrent for sorted list.
```

```
download_factory: don't check for "removed-right-after-add" when loading session

As no command is attached when loading from session, it is
impossible for this edge case to occur.

"find" on the download list, a "std::list" linked list, is
an O(n) operation. With it, the session loading is O(n^2),
where n is the number of entities in the session directory.

As such, remove this unnecessary check to speed things up.
```

```
main: bypass queuing in "load_session_torrents"

It is more expensive to queue all the items and then dequeue and
process them one by one, due to O(n*log(n)) time complexity of
"priority_queue", where n is the number of tasks already in the
queue, and memory reallocation.

We do not need task queuing in the synchronous loading of session.
After all, we called "priority_queue_perform" right after queuing.

As such, call "f->set_immediate(true)", so at any time the queue
has at most 1 task, which speeds up session loading.
```