### PR TITLE
Remove deprecated std::unary/binary_function

### DIFF
--- a/include/rpc/command_map.h
+++ b/include/rpc/command_map.h
@@ -14,8 +14,7 @@
 
 namespace rpc {
 
-struct command_map_comp
-  : public std::binary_function<const char*, const char*, bool> {
+struct command_map_comp {
   bool operator()(const char* arg1, const char* arg2) const {
     return std::strcmp(arg1, arg2) < 0;
   }

--- a/src/core/view.cc
+++ b/src/core/view.cc
@@ -17,8 +17,7 @@
 namespace core {
 
 // Also add focus thingie here?
-struct view_downloads_compare
-  : std::binary_function<Download*, Download*, bool> {
+struct view_downloads_compare {
   view_downloads_compare(const torrent::Object& cmd)
     : m_command(cmd) {}
 
@@ -61,7 +60,7 @@ struct view_downloads_compare
   const torrent::Object& m_command;
 };
 
-struct view_downloads_filter : std::unary_function<Download*, bool> {
+struct view_downloads_filter {
   view_downloads_filter(const torrent::Object& cmd, const torrent::Object& cmd2)
     : m_command(cmd)
     , m_command2(cmd2) {}

--- a/src/rpc/parse_commands.cc
+++ b/src/rpc/parse_commands.cc
@@ -16,13 +16,13 @@ CommandMap commands;
 RpcManager rpc;
 ExecFile   execFile;
 
-struct command_map_is_space : std::unary_function<char, bool> {
+struct command_map_is_space {
   bool operator()(char c) const {
     return c == ' ' || c == '\t';
   }
 };
 
-struct command_map_is_newline : std::unary_function<char, bool> {
+struct command_map_is_newline {
   bool operator()(char c) const {
     return c == '\n' || c == '\0' || c == ';';
   }


### PR DESCRIPTION
While building this on Arch, I received the following error:
```
src/rpc/parse_commands.cc:19:36: error: 'unary_function<char, bool>' is deprecated [-Werror,-Wdeprecated-declarations]                                                                
struct command_map_is_space : std::unary_function<char, bool> {                                                                                                                       
                                   ^                                                                                                                                                  
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/12.1.0/../../../../include/c++/12.1.0/bits/stl_function.h:124:7: note: 'unary_function<char, bool>' has been explicitly marked deprecated here
    } _GLIBCXX11_DEPRECATED;                                                                                                                                                          
      ^                                                                                                                                                                               
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/12.1.0/../../../../include/c++/12.1.0/x86_64-pc-linux-gnu/bits/c++config.h:103:32: note: expanded from macro '_GLIBCXX11_DEPRECATED'        
# define _GLIBCXX11_DEPRECATED _GLIBCXX_DEPRECATED                                                                                                                                    
                               ^                                                                                                                                                      
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/12.1.0/../../../../include/c++/12.1.0/x86_64-pc-linux-gnu/bits/c++config.h:94:46: note: expanded from macro '_GLIBCXX_DEPRECATED'           
# define _GLIBCXX_DEPRECATED __attribute__ ((__deprecated__))
```
From research, nothing inside rtorrent should require this base class, so I simply removed it. There's an associated PR for libtorrent here: https://github.com/jesec/libtorrent/pull/8