### PR TITLE
Move base64 data parsing to happen under load.raw

### DIFF
--- a/src/core/manager.cc
+++ b/src/core/manager.cc
@@ -439,15 +439,17 @@ Manager::try_create_download(const std::string&       uri,
   }
 
   if (flags & create_raw_data) {
-    f->load_raw_data(uri);
-  } else if (is_data_uri(uri)) {
-    const unsigned long start = uri.find("base64,", 5) + 7;
-    if (start >= uri.size()) {
-      throw torrent::input_error("Empty base64.");
-    }
+    if (is_data_uri(uri)) {
+      const unsigned long start = uri.find("base64,", 5) + 7;
+      if (start >= uri.size()) {
+        throw torrent::input_error("Empty base64.");
+      }
 
-    f->load_raw_data(base64Decode(std::string_view(uri.c_str() + start)));
-    f->variables()["tied_to_file"] = (int64_t)0;
+      f->load_raw_data(base64Decode(std::string_view(uri.c_str() + start)));
+      f->variables()["tied_to_file"] = (int64_t)0;
+    } else {
+      f->load_raw_data(uri);
+    }
   } else {
     f->load(uri);
   }


### PR DESCRIPTION
I remarked on this deviation from vanilla rTorrent #52, but just worked around it since my code already required changes for JSON-RPC anyway.