### PR TITLE
utils: lockfile: avoid stack overflow for lockfile buffer

### DIFF
--- a/src/utils/lockfile.cc
+++ b/src/utils/lockfile.cc
@@ -75,8 +75,9 @@ Lockfile::try_lock() {
   int  pos = ::gethostname(buf, 255);
 
   if (pos == 0) {
-    ::snprintf(buf + std::strlen(buf), 255, ":+%i\n", ::getpid());
-    ssize_t __attribute__((unused)) result = ::write(fd, buf, std::strlen(buf));
+    ssize_t len = std::strlen(buf);
+    ::snprintf(buf + len, 255 - len, ":+%i\n", ::getpid());
+    int __attribute__((unused)) result = ::write(fd, buf, std::strlen(buf));
   }
 
   ::close(fd);


### PR DESCRIPTION
Original patch by @cyphar was submitted to rakshasa/rtorrent at https://github.com/rakshasa/rtorrent/pull/1169.

Observed the segfault on nixos-unstable.